### PR TITLE
Added sanitize callback to fill a default value for all options. #4

### DIFF
--- a/includes/options-page.php
+++ b/includes/options-page.php
@@ -66,6 +66,19 @@ function sdwoo_sanitize_settings($options) {
 			$options[$key] = sanitize_text_field( $options[ $key ] );
 		}
 	}
+	
+	$as_arrays = array(
+		'product_ids',
+		'exclude_product_ids',
+		'product_categories',
+		'exclude_product_categories',
+	);
+
+	foreach ( $as_arrays as $key ) {
+		if (! is_array( $options[$key] ) ) {
+			$options[$key] = [];
+		}
+	}
 
 	return $options;
 }

--- a/includes/options-page.php
+++ b/includes/options-page.php
@@ -21,8 +21,53 @@ function admin_settings_page(){
 function sdwoo_register_settings(){
 	register_setting(
 		'subscriber_discounts_settings_group',
-		'sdwoo_settings'
+		'sdwoo_settings',
+		array(
+			'sanitize_callback' => 'sdwoo_sanitize_settings',
+		)
 	);
+}
+
+/**
+ * Sanitize settings.
+ */
+function sdwoo_sanitize_settings($options) {
+	$keys = array(
+		'mailchimp_key',
+		'activecampaign_key',
+		'discount_amount',
+		'discount_type',
+		'discount_use_one',
+		'date_expires',
+		'exclude_sale',
+		'same_email',
+		'discount_max',
+		'email_subject',
+		'from_email',
+		'from_name',
+		'name_placeholder',
+		'message',
+		'product_ids',
+		'exclude_product_ids',
+		'product_categories',
+		'exclude_product_categories',
+	);
+
+	foreach( $keys as $key ) {
+		if ( ! array_key_exists( $key, $options ) ) {
+			$options[$key] = null;
+
+			continue;
+		}
+
+		if ( is_array( $options[$key] ) ) {
+			$options[$key] = array_map( 'sanitize_text_field', $options[$key] );
+		} else if ( is_scalar( $options[$key] ) ) {
+			$options[$key] = sanitize_text_field( $options[ $key ] );
+		}
+	}
+
+	return $options;
 }
 
 add_action( 'admin_enqueue_scripts', 'sdwoo_searchable_menus' );


### PR DESCRIPTION
## Description
See issue. #4 

## How Has This Been Tested?
Save options in the subscriber-discounts-woo page. 
Run `wp option get sdwoo_settings` and see that all options is available with default null.

## Screenshots (jpeg or gifs if applicable):

## Types of changes
Define default option key value.
Sanitize value using sanitize_text_field.
Remove php warnings, undefined key.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.